### PR TITLE
Fixed misspelling of "wantlist" and nil managers on collection and wantlist

### DIFF
--- a/DiscogsAPI/User/DGUser.h
+++ b/DiscogsAPI/User/DGUser.h
@@ -34,7 +34,7 @@
 /**
  The wantlist endpoint.
  */
-@property (nonatomic,readonly) DGWantlist *wanlist;
+@property (nonatomic,readonly) DGWantlist *wantlist;
 
 /**
  The collection endpoint.

--- a/DiscogsAPI/User/DGUser.m
+++ b/DiscogsAPI/User/DGUser.m
@@ -32,7 +32,7 @@
 
 @implementation DGUser
 
-@synthesize wanlist     = _wanlist;
+@synthesize wantlist     = _wantlist;
 @synthesize collection  = _collection;
 
 + (DGUser*) user {
@@ -41,16 +41,18 @@
 
 #pragma mark Properties
 
-- (DGWantlist *)wanlist {
-    if (!_wanlist) {
-        _wanlist = [DGWantlist wantlist];
+- (DGWantlist *)wantlist {
+    if (!_wantlist) {
+        _wantlist = [DGWantlist wantlist];
+        _wantlist.manager = self.manager;
     }
-    return _wanlist;
+    return _wantlist;
 }
 
 - (DGCollection *)collection {
     if (!_collection) {
         _collection = [DGCollection collection];
+        _collection.manager = self.manager;
     }
     return _collection;
 }


### PR DESCRIPTION
Fixes https://github.com/maxep/DiscogsAPI/issues/4

After authenticating, asking for a user's collection, a collection endpoint with a `nil` manager is returned (same with wantlist.) Solution is to set the collection and wantlist's managers when first asked for.
